### PR TITLE
ci: client-id tokens and renovate mise.lock support

### DIFF
--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -300,7 +300,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-contents: write
 

--- a/.github/workflows/deprecate-app.yaml
+++ b/.github/workflows/deprecate-app.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
@@ -81,7 +81,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
@@ -116,7 +116,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-contents: write
 

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-issues: write
           permission-pull-requests: write

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -34,8 +34,10 @@ permissions:
 
 env:
   LOG_LEVEL: ${{ inputs.logLevel || 'debug' }}
+  RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["mise"]'
   RENOVATE_AUTODISCOVER: true
   RENOVATE_AUTODISCOVER_FILTER: ${{ github.repository }}
+  RENOVATE_CUSTOM_ENV_VARIABLES: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/renovate/repos"}'
   RENOVATE_DRY_RUN: ${{ inputs.dryRun == true }}
   RENOVATE_INTERNAL_CHECKS_FILTER: strict
   RENOVATE_PLATFORM: github
@@ -51,7 +53,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: "${{ secrets.BOT_APP_ID }}"
+          client-id: "${{ secrets.BOT_APP_ID }}"
           private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
           permission-issues: write
           permission-pull-requests: write


### PR DESCRIPTION
- `app-id` → `client-id` on `create-github-app-token` (input deprecated; the numeric App ID is valid there, no new secret needed)
- allow Renovate to run `mise lock` so tool bumps update `mise.lock` — fixes the failing `renovate/go-toolchain` PR